### PR TITLE
fix(safari): error when output samplerate too low for buffer

### DIFF
--- a/src/factories/connected-native-audio-buffer-source-node-factory.ts
+++ b/src/factories/connected-native-audio-buffer-source-node-factory.ts
@@ -14,7 +14,7 @@ export const createConnectedNativeAudioBufferSourceNodeFactory: TConnectedNative
             loopStart: 0,
             playbackRate: 1
         });
-        const nativeAudioBuffer = nativeContext.createBuffer(1, 2, nativeContext.sampleRate);
+        const nativeAudioBuffer = nativeContext.createBuffer(1, 2, 44100);
 
         nativeAudioBufferSourceNode.buffer = nativeAudioBuffer;
         nativeAudioBufferSourceNode.loop = true;

--- a/src/factories/convolver-node-constructor.ts
+++ b/src/factories/convolver-node-constructor.ts
@@ -49,7 +49,7 @@ export const createConvolverNodeConstructor: TConvolverNodeConstructorFactory = 
             if (value === null && this._nativeConvolverNode.buffer !== null) {
                 const nativeContext = this._nativeConvolverNode.context;
 
-                this._nativeConvolverNode.buffer = nativeContext.createBuffer(1, 1, nativeContext.sampleRate);
+                this._nativeConvolverNode.buffer = nativeContext.createBuffer(1, 1, 44100);
                 this._isBufferNullified = true;
             } else {
                 this._isBufferNullified = false;

--- a/src/factories/native-constant-source-node-faker-factory.ts
+++ b/src/factories/native-constant-source-node-faker-factory.ts
@@ -13,7 +13,7 @@ export const createNativeConstantSourceNodeFakerFactory: TNativeConstantSourceNo
     monitorConnections
 ) => {
     return (nativeContext, { offset, ...audioNodeOptions }) => {
-        const audioBuffer = nativeContext.createBuffer(1, 2, nativeContext.sampleRate);
+        const audioBuffer = nativeContext.createBuffer(1, 2, 44100);
         const audioBufferSourceNode = createNativeAudioBufferSourceNode(nativeContext, {
             buffer: null,
             channelCount: 2,

--- a/src/factories/wrap-audio-buffer-source-node-stop-method-nullified-buffer.ts
+++ b/src/factories/wrap-audio-buffer-source-node-stop-method-nullified-buffer.ts
@@ -4,7 +4,7 @@ export const createWrapAudioBufferSourceNodeStopMethodNullifiedBuffer: TWrapAudi
     overwriteAccessors
 ) => {
     return (nativeAudioBufferSourceNode, nativeContext) => {
-        const nullifiedBuffer = nativeContext.createBuffer(1, 1, nativeContext.sampleRate);
+        const nullifiedBuffer = nativeContext.createBuffer(1, 1, 44100);
 
         if (nativeAudioBufferSourceNode.buffer === null) {
             nativeAudioBufferSourceNode.buffer = nullifiedBuffer;


### PR DESCRIPTION
Closes https://github.com/chrisguttandin/standardized-audio-context/issues/956

- If Safari had an output device which set the default `AudioContext.sampleRate` to a value below 22050 Hz, a `NotSupportedError` was thrown when creating a new `AudioContext`.