### PR TITLE
fix: assign `Symbol.hasInstance` using `Object.defineProperty`

### DIFF
--- a/src/factories/audio-buffer-constructor.ts
+++ b/src/factories/audio-buffer-constructor.ts
@@ -19,7 +19,7 @@ export const createAudioBufferConstructor: TAudioBufferConstructorFactory = (
 ) => {
     let nativeOfflineAudioContext: null | TNativeOfflineAudioContext = null;
 
-    return class AudioBuffer implements IAudioBuffer {
+    class AudioBuffer implements IAudioBuffer {
         // This field needs to be defined to convince TypeScript that the IAudioBuffer will be implemented.
         public copyFromChannel!: (destination: Float32Array, channelNumber: number, bufferOffset?: number) => void;
 
@@ -89,12 +89,16 @@ export const createAudioBufferConstructor: TAudioBufferConstructorFactory = (
              */
             return audioBuffer;
         }
+    }
 
-        public static [Symbol.hasInstance](instance: unknown): boolean {
+    Object.defineProperty(AudioBuffer, Symbol.hasInstance, {
+        value: (instance: unknown): boolean => {
             return (
                 (instance !== null && typeof instance === 'object' && Object.getPrototypeOf(instance) === AudioBuffer.prototype) ||
                 audioBufferStore.has(<any>instance)
             );
         }
-    };
+    });
+
+    return AudioBuffer;
 };

--- a/src/factories/periodic-wave-constructor.ts
+++ b/src/factories/periodic-wave-constructor.ts
@@ -11,7 +11,7 @@ export const createPeriodicWaveConstructor: TPeriodicWaveConstructorFactory = (
     periodicWaveStore,
     sanitizePeriodicWaveOptions
 ) => {
-    return class PeriodicWave<T extends TContext> implements IPeriodicWave {
+    class PeriodicWave<T extends TContext> implements IPeriodicWave {
         constructor(context: T, options?: Partial<IPeriodicWaveOptions>) {
             const nativeContext = getNativeContext(context);
             const mergedOptions = sanitizePeriodicWaveOptions({ ...DEFAULT_OPTIONS, ...options });
@@ -22,12 +22,16 @@ export const createPeriodicWaveConstructor: TPeriodicWaveConstructorFactory = (
             // This does violate all good pratices but it is used here to simplify the handling of periodic waves.
             return periodicWave;
         }
+    }
 
-        public static [Symbol.hasInstance](instance: unknown): boolean {
+    Object.defineProperty(PeriodicWave, Symbol.hasInstance, {
+        value: (instance: unknown): boolean => {
             return (
                 (instance !== null && typeof instance === 'object' && Object.getPrototypeOf(instance) === PeriodicWave.prototype) ||
                 periodicWaveStore.has(<any>instance)
             );
         }
-    };
+    });
+
+    return PeriodicWave;
 };


### PR DESCRIPTION
Under certain build conditions, Babel can crash if `Symbol.hasInstance` is assigned directly ([reference](https://github.com/babel/babel/issues/2286)).

This commit replaces direct static method definitions with calls to `Object.defineProperty`, which seems to appease Babel.

Fixes #986.