### PR TITLE
feat(package): export type guards

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -179,6 +179,16 @@ import {
     CONTEXT_STORE,
     CYCLE_COUNTERS
 } from './globals';
+export { isAudioBufferSourceNode } from './guards/audio-buffer-source-node';
+export { isAudioNodeOutputConnection } from './guards/audio-node-output-connection';
+export { isAudioNode } from './guards/audio-node';
+export { isAudioWorkletNode } from './guards/audio-worklet-node';
+export { isBiquadFilterNode } from './guards/biquad-filter-node';
+export { isConstantSourceNode } from './guards/constant-source-node';
+export { isDelayNode } from './guards/delay-node';
+export { isGainNode } from './guards/gain-node';
+export { isOscillatorNode } from './guards/oscillator-node';
+export { isStereoPannerNode } from './guards/stereo-panner-node';
 import { connectNativeAudioNodeToNativeAudioNode } from './helpers/connect-native-audio-node-to-native-audio-node';
 import { disconnectNativeAudioNodeFromNativeAudioNode } from './helpers/disconnect-native-audio-node-from-native-audio-node';
 import { getAudioNodeConnections } from './helpers/get-audio-node-connections';


### PR DESCRIPTION
This PR aims to solve #1011.

By exporting type guards consumers, like myself, can use said type guards to narrow down different audio nodes for different behaviours. I am currently experimenting with creating a declarative audio renderer, hence my need to narrow down declared nodes to their instances.

I have built and verified that I can import it and use it from another project.